### PR TITLE
Add hydrus robot model for MBZIRC2020 Task2

### DIFF
--- a/mbzirc2020_task2/README.md
+++ b/mbzirc2020_task2/README.md
@@ -1,3 +1,14 @@
+## Installation
+
+```
+cd <catkin_ws>
+wstool merge -t src src/aerial_robot_demo/mbzirc2020_task2/mbzirc_task2.rosinstall
+wstool update -t src
+rosdep install -y -r --from-paths src --ignore-src --rosdistro $ROS_DISTRO
+catkin build
+```
+
+
 ## How to run simulation
 Default
 ```

--- a/mbzirc2020_task2/mbzirc2020_task2.rosinstall
+++ b/mbzirc2020_task2/mbzirc2020_task2.rosinstall
@@ -1,0 +1,10 @@
+# https://github.com/tu-darmstadt-ros-pkg/hector_quadrotor
+- git:
+    local-name: gazebo-pkgs
+    uri: https://github.com/JenniferBuehler/gazebo-pkgs
+    version: 1.0.2
+
+- git:
+    local-name: general-message-pkgs
+    uri: https://github.com/JenniferBuehler/general-message-pkgs
+    version: 1.0.0

--- a/mbzirc2020_task2/mbzirc2020_task2_common/config/MotorInfo.yaml
+++ b/mbzirc2020_task2/mbzirc2020_task2_common/config/MotorInfo.yaml
@@ -1,0 +1,28 @@
+motor_info:
+        min_thrust: 1 #[N]
+        max_thrust: 16 #[N]
+        abs_max_pwm: 0.9
+        force_landing_thrust: 6.5 #[N]
+        m_f_rate: -0.01636
+        pwm_conversion_mode: 0 # SQRT Mode
+        vel_ref_num: 4
+        ref1:        
+                voltage: 25.2
+                polynominal2: 0.059976113 # x10
+                polynominal1: -3.660731 # x10
+                polynominal0: 2.125751 # x1
+        ref2:
+                voltage: 24.2        
+                polynominal2: 0.06047878 # x10
+                polynominal1: -4.131479 # x10
+                polynominal0: 4.587418 # x1
+        ref3:
+                voltage: 23.2        
+                polynominal2: 0.056440896 # x10
+                polynominal1: -3.8695979 # x10
+                polynominal0: 4.2894956 # x1
+        ref4:
+                voltage: 22.2        
+                polynominal2: 0.05945578 # x10
+                polynominal1: -4.7306816 # x10
+                polynominal0: 8.0611266 # x1                 

--- a/mbzirc2020_task2/mbzirc2020_task2_common/config/quad/Battery.yaml
+++ b/mbzirc2020_task2/mbzirc2020_task2_common/config/quad/Battery.yaml
@@ -1,0 +1,5 @@
+bat_info:
+        bat_cell: 6
+        bat_resistance: 0.08 # [m Ohm]
+        hovering_current: 10 #[A], MN3510, prop14inch, 3 ~ 4.5
+        low_voltage_thre: 1 #[100%]

--- a/mbzirc2020_task2/mbzirc2020_task2_common/config/quad/DifferentialFlatnessPidControlConfig.yaml
+++ b/mbzirc2020_task2/mbzirc2020_task2_common/config/quad/DifferentialFlatnessPidControlConfig.yaml
@@ -1,0 +1,32 @@
+### Differential Flatness PID control for hydrusx quad type
+
+controller:
+        # alt [N]
+        alt:
+                offset: 0
+                limit: 16.5
+                p_term_limit: 16.5
+                i_term_limit: 16.5
+                d_term_limit: 16.5
+                alt_landing_const_i_ctrl_thresh: -0.2
+
+        # xy [rad]
+        xy:
+                p_gain: 0.15
+                i_gain: 0.002
+                hovering_i_gain: 0.001
+                d_gain: 0.4
+                limit: 0.3 
+                p_term_limit: 0.2 
+                i_term_limit: 0.15
+                d_term_limit: 0.2
+                x_offset: 0
+                y_offset: 0
+
+        # yaw [N]
+        yaw:
+                limit: 6.0
+                p_term_limit: 4.5
+                i_term_limit: 4.0
+                d_term_limit: 4.0
+                err_thresh: 0.4

--- a/mbzirc2020_task2/mbzirc2020_task2_common/config/quad/Hydrus.yaml
+++ b/mbzirc2020_task2/mbzirc2020_task2_common/config/quad/Hydrus.yaml
@@ -1,0 +1,32 @@
+#HydrusX Quad config
+
+control_rate: 15.0
+
+baselink: fc #flight controller
+
+only_three_axis_mode: false
+gyro_moment_compensation: true
+
+q_roll: 400
+q_roll_d: 40
+q_roll_i: 10.0
+q_pitch: 400
+q_pitch_d: 40
+q_pitch_i: 10.0
+
+q_yaw: 100
+q_yaw_d:  50
+q_yaw_i: 0.5
+
+q_z: 10.0
+q_z_d: 20.0
+q_z_i: 10.0
+
+r1: 1.0
+r2: 1.0
+r3: 1.0
+r4: 1.0
+
+stability_margin_thre: 0.13
+f_max: 16.5
+f_min: 2.0

--- a/mbzirc2020_task2/mbzirc2020_task2_common/config/quad/RvizInit.yaml
+++ b/mbzirc2020_task2/mbzirc2020_task2_common/config/quad/RvizInit.yaml
@@ -1,0 +1,4 @@
+zeros:
+  joint1: 1.57
+  joint2: 1.57
+  joint3: 1.57

--- a/mbzirc2020_task2/mbzirc2020_task2_common/config/quad/Servo.yaml
+++ b/mbzirc2020_task2/mbzirc2020_task2_common/config/quad/Servo.yaml
@@ -1,0 +1,36 @@
+hydrusx:
+  servo_controller:
+    joints:
+      state_sub_topic: /servo/states
+      ctrl_pub_topic: /servo/target_states
+      torque_pub_topic: /servo/torque_enable
+      angle_sgn: 1
+      angle_scale: 0.001534
+      zero_point_offset: 2047
+      torque_scale: 0.00735 # convert to N*m
+
+      # for simulation
+      simulation:
+        pid: {p: 50.0, i: 0.01, d: 2.0}
+        init_value: 1.57
+        type: effort_controllers/JointPositionController
+
+      # should be in order in terms of kinematics model
+      # i.e. joint1 -> jointN
+      controller1:
+        id: 0
+        name: joint1
+        #angle_max: 1.58 # you can specify for each controller
+
+        #simulaton:  # you can specify for each controller
+          #type: effort_controllers/JointPositionController
+          #pid: {p: 50.0, i: 0.01, d: 2.0}
+          #init_value: 0
+
+      controller2:
+        id: 1
+        name: joint2
+      controller3:
+        id: 2
+        name: joint3
+

--- a/mbzirc2020_task2/mbzirc2020_task2_common/config/quad/TeleopNavigationConfig.yaml
+++ b/mbzirc2020_task2/mbzirc2020_task2_common/config/quad/TeleopNavigationConfig.yaml
@@ -1,0 +1,17 @@
+# Teleop Basic Param
+
+navigator:
+        verbose: false
+        takeoff_height: 0.5
+
+        # teleop operation
+        max_target_vel: 1.5
+        joy_target_vel_interval: 0.01  # 0.2 / 20 = 0.01, 0.005 ~ 0.01  m/s
+        joy_target_alt_interval: 0.02
+        max_target_yaw_rate: 1.0 #  0.05 
+        cmd_vel_lev2_gain : 2.0
+        nav_vel_limit : 0.3
+
+        gain_tunning_mode: 0
+        max_target_tilt_angle: 0.2
+        cmd_angle_lev2_gain : 1.5

--- a/mbzirc2020_task2/mbzirc2020_task2_common/config/quad/egomotion_estimation/mbzirc2020_task2_quad.yaml
+++ b/mbzirc2020_task2/mbzirc2020_task2_common/config/quad/egomotion_estimation/mbzirc2020_task2_quad.yaml
@@ -1,0 +1,62 @@
+# Sensor Fuser Loader
+estimator:
+        # sensor plugin
+        sensor_list:
+        - sensor_plugin/imu
+        - sensor_plugin/mocap
+        - sensor_plugin/alt
+        - sensor_plugin/vo
+        - sensor_plugin/gps
+
+
+        # egomotion estimation
+        egomotion_list:
+        - kalman_filter/kf_pos_vel_acc
+        - kalman_filter/kf_pos_vel_acc
+        #- aerial_robot_base/kf_xy_roll_pitch_bias
+        - kalman_filter/kf_pos_vel_acc
+
+        # experiment estimation
+        experiment_list:
+        - kalman_filter/kf_pos_vel_acc
+        - kalman_filter/kf_pos_vel_acc
+        - kalman_filter/kf_pos_vel_acc
+
+        # specific id(int) of sensor fuser, axis for kf
+        fuser_egomotion_id1: 8 # 1 << 3
+        fuser_egomotion_id2: 16 # 1 << 4
+        fuser_egomotion_id3: 32 # 1 << 5
+        #fuser_egomotion_id1: 24 # 1 << 3 + 1 << 4
+        #fuser_egomotion_id2: 32 # 1 << 5
+
+        fuser_experiment_id1: 8 # 1 << 3
+        fuser_experiment_id2: 16 # 1 << 4
+        fuser_experiment_id3: 32 # 1 << 5
+
+        # specific name of sensor fuser
+        fuser_egomotion_name1: /ee/x
+        fuser_egomotion_name2: /ee/y
+        fuser_egomotion_name3: /ee/z
+        #fuser_egomotion_name1: /ee/xy
+        #fuser_egomotion_name2: /ee/z
+
+        fuser_experiment_name1: /ex/x
+        fuser_experiment_name2: /ex/y
+        fuser_experiment_name3: /ex/z
+
+
+# EGOMOTION_ESTIMATION_MODE = 0
+# EXPERIMENT_MODE = 1
+# GROUND_TRUTH_MODE = 2
+
+/sensor_plugin:
+        imu:
+                estimate_mode: 3 # 1<<0 + 1<<1
+        mocap:
+                estimate_mode: 6 # 1<<1 + 1<<2
+        alt:
+                estimate_mode: 1 # 1<<0
+        gps:
+                estimate_mode: 1 # 1<<0
+        vo:
+                estimate_mode: 1 # 1<<0

--- a/mbzirc2020_task2/mbzirc2020_task2_common/config/quad/egomotion_estimation/simulation.yaml
+++ b/mbzirc2020_task2/mbzirc2020_task2_common/config/quad/egomotion_estimation/simulation.yaml
@@ -1,0 +1,16 @@
+# Sensor Fuser Loader
+estimator:
+        # sensor plugin
+        sensor_list:
+        - sensor_plugin/mocap
+
+# EGOMOTION_ESTIMATION_MODE = 0
+# GROUND_TRUTH_MODE = 1
+# EXPERIMENT_MODE = 2
+
+/sensor_plugin:
+        mocap:
+                estimate_mode: 2 #1 << 1
+                unhealth_level: 3
+                health_timeout: 0.5
+                ground_truth_sub_name: /hydrusx/ground_truth

--- a/mbzirc2020_task2/mbzirc2020_task2_common/launch/bringup.launch
+++ b/mbzirc2020_task2/mbzirc2020_task2_common/launch/bringup.launch
@@ -1,10 +1,12 @@
 <?xml version="1.0"?>
 <launch>
+  ###########  launch config  ###########
   <arg name="real_machine" default="True" />
   <arg name="simulation" default="False" />
   <arg name="control_mode" default="0" />
+  <arg name="launch_gazebo" default="True" />
   <arg name="type" default="quad" />
-  <arg name="onboards_model" default="tx2_zed_201810" />
+  <arg name="onboards_model" default="mbzirc2020_task2_quad" />
   <arg name="estimate_mode"  default= "0" />
   <arg name="headless" default="True" />
   <arg name="worldtype" default="default" />
@@ -12,18 +14,92 @@
   <arg name="spawn_y" default="0.0"/>
   <arg name="spawn_z" default="0.5"/>
   <arg name="spawn_yaw" default="0.0"/>
+  <arg name="direct_model" value="false" />
+  <arg name="direct_model_name" />
 
-  ########## UAV HYDRUS SPAWNER ##########
-  <include file="$(find hydrus)/launch/bringup.launch">
-    <arg name="real_machine" default="$(arg real_machine)" />
-    <arg name="simulation" default="$(arg simulation)" />
-    <arg name="control_mode" default="$(arg control_mode)" />
-    <arg name="type" default="$(arg type)" />
-    <arg name="onboards_model" default="$(arg onboards_model)" />
-    <arg name="estimate_mode"  default= "$(arg estimate_mode)" />
+
+  ###########  UAV Config  ###########
+  # HYDRUS = 16 # 0x10, hydrus type with  4dof underactuated property
+  <param name="/uav_info/uav_model" value= "16" />
+
+  ###########  Motor Config  ###########
+  <rosparam file="$(find mbzirc2020_task2_common)/config/MotorInfo.yaml" command="load" />
+
+  ###########  Servo Config  ###########
+  <rosparam file="$(find mbzirc2020_task2_common)/config/$(arg type)/Servo.yaml" command="load" />
+
+  ###########  Battery Config  ###########
+  <rosparam file="$(find mbzirc2020_task2_common)/config/$(arg type)/Battery.yaml" command="load" />
+
+  ###########  Base Platform  ###########
+  <node pkg="aerial_robot_base" type="aerial_robot_base_node" name="aerial_robot_base_node" output="screen" >
+
+    ###########  Basic Param  ###########
+    # EGOMOTION_ESTIMATE = 0
+    # EXPERIMENT_ESTIMATE = 1. for unstable mocap, use this mode
+    # GROUND_TRUTH = 2
+    <param name="estimator/estimate_mode" value= "2" if="$(arg simulation)" />
+    <param name="estimator/estimate_mode" value= "$(arg estimate_mode)" if="$(arg real_machine)"/>
+
+    # World Pos Control Mode: 0
+    # World Vel Control Mode: 2
+    # Local Vel Control Mode: 3
+    # Attitude Control Mode: 4
+    <param name="navigator/xy_control_mode"  value="$(arg control_mode)"/>
+
+    <param name="simulation" value="$(arg simulation)" />  <!--for sensor plugin-->
+    <param name="param_verbose" value="false"/>
+    <param name="main_rate" type="double" value="40"/>
+
+    ###########  Sensor Fusion  ###########
+    <rosparam file="$(find mbzirc2020_task2_common)/config/$(arg type)/egomotion_estimation/$(arg onboards_model).yaml" command="load" if="$(arg real_machine)"/>
+    <rosparam file="$(find mbzirc2020_task2_common)/config/$(arg type)/egomotion_estimation/simulation.yaml" command="load" if="$(eval arg('simulation') * (1 - arg('real_machine')))"/>
+    <remap from="/joint_states" to="/hydrusx/joint_states"/>
+
+    ###########  PID Control  ###########
+    <rosparam file="$(find mbzirc2020_task2_common)/config/$(arg type)/DifferentialFlatnessPidControlConfig.yaml" command="load" />
+
+    ###########  Teleop  ###########
+    <rosparam file="$(find mbzirc2020_task2_common)/config/$(arg type)/TeleopNavigationConfig.yaml" command="load" />
+  </node>
+
+  ###########  Robot Model  ###########
+  <include file="$(find mbzirc2020_task2_common)/launch/robot_model.launch" >
+    <arg name="type" value="$(arg type)" />
+    <arg name="onboards_model" value="$(arg onboards_model)"/>
+    <arg name="headless" value="$(arg headless)" />
+    <arg name="need_joint_state" value="false" if ="$(eval arg('simulation') + arg('real_machine') > 0)"/>
+    <arg name="description_mode" value="gazebo" if="$(arg simulation)"/>
+    <arg name="direct_model" value="$(arg direct_model)" />
+    <arg name="direct_model_name" value="$(arg direct_model_name)" if="$(arg direct_model)"/>
+  </include >
+
+  ###########  Transform Control  ###########
+  <node pkg="hydrus" type="transform_control_node" name="hydrusx"  output="screen" respawn="false">
+    <rosparam file="$(find mbzirc2020_task2_common)/config/$(arg type)/Hydrus.yaml" command="load" />
+    <remap from="joint_states" to="hydrusx/joint_states"/>
+    <param name="kinematic_verbose" value="false" />
+    <param name="control_verbose" value="false" />
+    <param name="debug_verbose" value="false" />
+    <param name="verbose" value="false"/>
+  </node>
+
+  ###########  Sensors  ###########
+  <include file="$(find mbzirc2020_task2_common)/launch/includes/$(arg onboards_model)/sensors.launch.xml" >
+    <arg name="real_machine" value="$(arg real_machine)" />
+    <arg name="simulation" value="$(arg simulation)" />
+  </include >
+
+  ###########  Servo Bridge  ###########
+  <node pkg="aerial_robot_model" type="servo_bridge_node" name="servo_bridge"  output="screen"  ns="hydrusx" />
+
+  ########## Simulation in Gazebo #########
+  <include file="$(find aerial_robot_simulation)/launch/simulation.launch" if = "$(eval arg('simulation') * (1 - arg('real_machine')))" >
+    <arg name="model" default="hydrusx" />
+    <arg name="gui" default="false" if="$(arg headless)" />
     <arg name="headless" default="$(arg headless)" />
-    <arg name="worldtype" default="$(find mbzirc2020_task2_simulation)/gazebo_model/world/mbzirc2020_task2_$(arg worldtype).world" />
-    <arg name="launch_gazebo" default="True" />
+    <arg name="launch_gazebo" default="$(arg launch_gazebo)" />
+    <arg name="worldtype" value="$(find mbzirc2020_task2_simulation)/gazebo_model/world/mbzirc2020_task2_$(arg worldtype).world" />
     <arg name="spawn_x" value="$(arg spawn_x)" />
     <arg name="spawn_y" value="$(arg spawn_y)" />
     <arg name="spawn_z" value="$(arg spawn_z)" />

--- a/mbzirc2020_task2/mbzirc2020_task2_common/launch/includes/mbzirc2020_task2_quad/sensors.launch.xml
+++ b/mbzirc2020_task2/mbzirc2020_task2_common/launch/includes/mbzirc2020_task2_quad/sensors.launch.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<launch>
+
+  <arg name="real_machine" default="false" />
+  <arg name="simulation" default="false" />
+
+  <group if="$(arg real_machine)">
+    <group unless="$(arg simulation)">
+      <!-- fc & IMU & GPS -->
+      <include file="$(find spinal_ros_bridge)/launch/serial.launch" >
+        <arg name="baud" value="921600" />
+        <arg name="port" value="/dev/flight_controller" />
+      </include>
+
+      <!-- zed mini & VIO in zed SDK -->
+      <include file="$(find zed_wrapper)/launch/zed.launch" />
+      <param name="/zed/zed_wrapper_node/publish_map_tf" value="false" />
+      <param name="/zed/zed_wrapper_node/publish_tf" value="false" />
+
+      <!-- mocap -->
+      <include file="$(find aerial_robot_base)/launch/external_module/mocap.launch" />
+
+      <!-- leddar one -->
+      <include file="$(find leddar_one)/launch/leddar_one.launch" />
+
+    </group>
+  </group>
+
+  <!-- basic configuration for sensors (e.g. noise sigma) -->
+  <rosparam file="$(find hydrus)/config/sensors/imu/spinal.yaml" command="load" />
+  <rosparam file="$(find aerial_robot_base)/config/sensors/gps/ublox_m8n.yaml" command="load" />
+  <rosparam file="$(find hydrus)/config/sensors/vo/zed_mini.yaml" command="load" />
+  <rosparam file="$(find aerial_robot_base)/config/sensors/mocap.yaml" command="load" />
+  <rosparam file="$(find aerial_robot_base)/config/sensors/altmeter/leddar_one.yaml" command="load" />
+</launch>

--- a/mbzirc2020_task2/mbzirc2020_task2_common/launch/robot_model.launch
+++ b/mbzirc2020_task2/mbzirc2020_task2_common/launch/robot_model.launch
@@ -1,0 +1,34 @@
+<launch>
+  <arg name="type" default = "quad" />
+  <arg name="onboards_model"  default = "default" />
+  <arg name="direct_model" default="false" />
+  <arg name="direct_model_name" />
+  <arg name="headless" default="False" />
+  <arg name="description_mode" default="urdf"/>
+  <arg name="need_joint_state" default="true" />
+  <arg name="node_suffix" default="" />
+
+  <group ns="hydrusx" >
+    <node name="robot_state_publisher_$(arg node_suffix)" pkg="robot_state_publisher" type="state_publisher" />
+
+    <rosparam file = "$(find mbzirc2020_task2_common)/config/$(arg type)/RvizInit.yaml" command="load" />
+    <group if="$(arg need_joint_state)">
+      <param name="use_gui" value="true" />
+      <node name="joint_state_publisher_$(arg node_suffix)" pkg="joint_state_publisher" type="joint_state_publisher" >
+        <param name="robot_description"
+               command="$(find xacro)/xacro '$(find mbzirc2020_task2_common)/robots/$(arg type)/$(arg onboards_model).urdf.xacro'" />
+      </node >
+    </group>
+
+    <node name="aerial_robot_model_$(arg node_suffix)" pkg="aerial_robot_model" type="rotor_tf_publisher" unless="$(arg need_joint_state)"/>
+
+  </group>
+
+  <include file="$(find aerial_robot_model)/launch/aerial_robot_model.launch" >
+    <arg name="headless" value="$(arg headless)" />
+    <arg name="robot_model" value="$(find mbzirc2020_task2_common)/robots/$(arg type)/$(arg onboards_model).$(arg description_mode).xacro" unless="$(arg direct_model)"/>
+    <arg name="robot_model" value="$(arg direct_model_name)" if="$(arg direct_model)"/>
+    <arg name="node_suffix" value="$(arg node_suffix)" />
+  </include>
+
+</launch>

--- a/mbzirc2020_task2/mbzirc2020_task2_common/robots/onboards/mbzirc2020_task2_quad/onboards.gazebo.xacro
+++ b/mbzirc2020_task2/mbzirc2020_task2_common/robots/onboards/mbzirc2020_task2_quad/onboards.gazebo.xacro
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+<robot
+    xmlns:xacro="http://www.ros.org/wiki/xacro" name="hydrusx" >
+
+  <!-- robot urdf and gazebo plugin for sensors-->
+  <xacro:include filename="$(find hydrus)/robots/default.gazebo.xacro" />
+
+    <!-- stereo camera: depth, color based on left camera -->
+  <xacro:extra_module name = "zed_left_camera_frame" parent = "zed_camera_center">
+    <origin xyz="0.002 0.03 0" rpy="0 0 0"/>
+    <inertial>
+      <mass value = "0.00001" />
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <inertia
+          ixx="0.000001" ixy="0.0" ixz="0.0"
+          iyy="0.000001" iyz="0.0"
+          izz="0.000002"/>
+    </inertial>
+  </xacro:extra_module>
+  <xacro:extra_module name = "zed_left_camera_optical_frame" parent = "zed_left_camera_frame">
+    <origin xyz="0 0 0" rpy="${-pi / 2} 0 ${-pi / 2}"/>
+    <inertial>
+      <mass value = "0.00001" />
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <inertia
+          ixx="0.000001" ixy="0.0" ixz="0.0"
+          iyy="0.000001" iyz="0.0"
+          izz="0.000002"/>
+    </inertial>
+  </xacro:extra_module>
+
+  <gazebo reference="zed_left_camera_frame">
+    <sensor type="depth" name="zed_depth_camera">
+      <update_rate>20.0</update_rate>
+      <camera name="head">
+        <horizontal_fov>1.57</horizontal_fov>
+        <image>
+          <width>1280</width>
+          <height>720</height>
+          <format>RGB</format>
+        </image>
+        <clip>
+          <near>0.02</near>
+          <far>300</far>
+        </clip>
+        <noise>
+          <type>gaussian</type>
+          <mean>0.0</mean>
+          <stddev>0.007</stddev>
+        </noise>
+      </camera>
+      <plugin name="depth_camera" filename="libgazebo_ros_openni_kinect.so">
+        <baseline>0.06</baseline>
+        <alwaysOn>true</alwaysOn>
+        <updateRate>0.0</updateRate>
+        <cameraName>zed</cameraName>
+        <imageTopicName>rgb/image_rect_color</imageTopicName>
+        <cameraInfoTopicName>rgb/camera_info</cameraInfoTopicName>
+        <depthImageTopicName>depth/depth_registered</depthImageTopicName>
+        <depthImageInfoTopicName>depth/camera_info</depthImageInfoTopicName>
+        <pointCloudTopicName>point_cloud/cloud_registered</pointCloudTopicName>
+        <frameName>zed_left_camera_optical_frame</frameName>
+        <pointCloudCutoff>0.05</pointCloudCutoff>
+        <distortionK1>0</distortionK1>
+        <distortionK2>0</distortionK2>
+        <distortionK3>0</distortionK3>
+        <distortionT1>0</distortionT1>
+        <distortionT2>0</distortionT2>
+        <CxPrime>0</CxPrime>
+        <Cx>0</Cx>
+        <Cy>0</Cy>
+        <focalLength>0</focalLength>
+        <hackBaseline>0</hackBaseline>
+      </plugin>
+    </sensor>
+  </gazebo>
+
+
+  <!-- gazebo grasp plugin -->
+  <xacro:include filename="$(find mbzirc2020_task2_simulation)/urdf/gzplugin_grasp_fix.urdf.xacro" />
+  <xacro:gzplugin_grasp_fix />
+
+</robot>

--- a/mbzirc2020_task2/mbzirc2020_task2_common/robots/onboards/mbzirc2020_task2_quad/onboards.urdf.xacro
+++ b/mbzirc2020_task2/mbzirc2020_task2_common/robots/onboards/mbzirc2020_task2_quad/onboards.urdf.xacro
@@ -1,0 +1,140 @@
+<?xml version="1.0"?>
+<robot
+    xmlns:xacro="http://www.ros.org/wiki/xacro" name="hydrusx" >
+
+  <xacro:include filename="$(find mbzirc2020_task2_common)/urdf/common.xacro" />
+
+  <xacro:macro name="onboards" params="link">
+
+    <!-- flight controller -->
+    <xacro:extra_module name = "fc" parent = "link${link}" visible = "1"
+                        model_url = "package://hydrus/urdf/mesh/modules/flight_controller/fc_euclid201806.dae"> <!-- same with intel euclid -->
+      <origin xyz="${link_length / 2 + 0.2281} ${-4.4*0.001} 0.03533" rpy="0 0 0"/>
+      <inertial>
+        <mass value = "0.05" />
+        <origin xyz="${11.48*0.001} ${4.3*0.001} ${-9.4*0.001}" rpy="0 0 0"/>
+        <inertia
+            ixx="0.00001" ixy="0.0" ixz="0.0"
+            iyy="0.00001" iyz="0.0"
+            izz="0.00002"/>
+      </inertial>
+    </xacro:extra_module>
+
+    <!-- gps -->
+    <xacro:extra_module name = "gps" parent = "link${link}" visible = "1"
+                        model_url = "package://hydrus/urdf/mesh/modules/sensor/gps_ublox_m8n.dae">
+      <origin xyz="${link_length/2 + 0.206} 0.0 0.18" rpy="0 0 0"/>
+      <inertial>
+        <origin xyz="0.000000 0.000000 -0.062510" rpy="0 0 0"/>
+        <mass value="0.053000"/>
+        <inertia
+            ixx="0.000503" iyy="0.000503" izz="0.000010"
+            ixy="0.000000" ixz="0.000000" iyz="0.000000"/>
+      </inertial>
+    </xacro:extra_module>
+    <xacro:extra_module name = "magnet" parent = "gps">
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <inertial>
+        <mass value = "0.00001" />
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <inertia
+            ixx="0.000001" ixy="0.0" ixz="0.0"
+            iyy="0.000001" iyz="0.0"
+            izz="0.000002"/>
+      </inertial>
+    </xacro:extra_module>
+
+    <!-- leddar one -->
+    <xacro:extra_module name = "leddarone" parent = "link${link + 1}" visible = "1"
+                        model_url = "package://hydrus/urdf/mesh/modules/sensor/leddar_one_tx2_attached_mode.dae">
+      <origin xyz="0.0866 0.0 -0.06267" rpy="0 ${pi} 0"/>
+      <inertial>
+        <origin xyz="-0.007950 0.000000 -0.000140" rpy="0 0 0"/>
+        <mass value="0.029000"/>
+        <inertia
+            ixx="0.000010" iyy="0.000008" izz="0.000008"
+            ixy="0.000000" ixz="0.000000" iyz="0.000000"/>
+      </inertial>
+    </xacro:extra_module>
+
+    <!-- processor: jetson tx2 -->
+    <xacro:extra_module name = "pc" parent = "link${link + 1}" visible = "1"
+                        model_url = "package://hydrus/urdf/mesh/modules/processor/jetson_tx2.dae"
+                        scale="0.001" >
+      <origin xyz="0.086 0.0 ${-0.0192}" rpy="${pi/2} 0 ${pi}"/>
+      <inertial>
+        <mass value = "0.181" />
+        <origin xyz="0 ${-5 * 0.001} 0" rpy="0 0 0"/>
+        <inertia
+            ixx="0.00001" ixy="0.0" ixz="0.0"
+            iyy="0.00001" iyz="0.0"
+            izz="0.00001"/>
+      </inertial>
+    </xacro:extra_module>
+
+    <!-- sensor: zed mini with servo -->
+    <xacro:extra_module name = "zed_mini_servo_up" parent = "link${link}" visible = "1"
+                        model_url = "package://hydrus/urdf/mesh/modules/sensor/zed_mini_servo_up.dae">
+      <origin xyz="${link_length/2 + 0.28715} 0.0 -0.04015" rpy="0 0 0"/>
+      <inertial>
+        <mass value = "0.021" />
+        <origin xyz="${-21.77 * 0.001} 0 ${10.3 * 0.001}" rpy="0 0 0"/>
+        <inertia
+            ixx="0.0" ixy="0.0" ixz="0.0"
+            iyy="0.0" iyz="0.0"
+            izz="0.0"/>
+      </inertial>
+    </xacro:extra_module>
+
+
+    <joint name="zed_mini_servo_joint" type="revolute">
+      <limit effort="0.2" lower="-1.6" upper="1.6" velocity="0.1"/>
+      <parent link="zed_mini_servo_up"/>
+      <child link="zed_mini_servo_down"/>
+      <origin rpy="0 0 0" xyz="0 0.0 0"/>
+      <axis xyz="1 0 0"/>
+      <dynamics damping="0.01" friction="0.0"/>
+    </joint>
+
+    <link name="zed_mini_servo_down">
+      <inertial>
+        <origin xyz="${-21.35 * 0.001} 0 ${-16.4 * 0.001}" rpy="0 0 0"/>
+        <mass value="0.079" />
+        <inertia
+            ixx="0.00001" iyy="0.00012" izz="0.00012"
+            ixy="0" ixz="0" iyz="0"/>
+      </inertial>
+      <visual>
+        <origin xyz="${-14.75 * 0.001} 0 ${-19 * 0.001}" rpy="0 ${pi/2} ${-pi}"/>
+        <geometry>
+          <mesh filename="package://hydrus/urdf/mesh/modules/sensor/zed_mini_servo_down.dae"/>
+        </geometry>
+      </visual>
+    </link>
+
+    <!-- to create the zed center frame -->
+    <xacro:extra_module name = "zed_camera_center" parent = "zed_mini_servo_down" visible = "0" >
+      <origin xyz="${-14.75 * 0.001} 0 ${-19 * 0.001}" rpy="0 ${pi/2} ${pi/2}"/>
+      <inertial>
+        <mass value = "0.0" />
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <inertia
+            ixx="0.0" ixy="0.0" ixz="0.0"
+            iyy="0.0" iyz="0.0"
+            izz="0.0"/>
+      </inertial>
+    </xacro:extra_module>
+
+
+    <transmission name="zed_mini_servo_joint_tran">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="zed_mini_servo_joint">
+        <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="zed_mini_servo_joint">
+        <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+  </xacro:macro>
+</robot>

--- a/mbzirc2020_task2/mbzirc2020_task2_common/robots/quad/mbzirc2020_task2_quad.gazebo.xacro
+++ b/mbzirc2020_task2/mbzirc2020_task2_common/robots/quad/mbzirc2020_task2_quad.gazebo.xacro
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<robot
+    xmlns:xacro="http://www.ros.org/wiki/xacro" name="hydrusx" >
+
+  <!-- robot urdf -->
+  <xacro:include filename="$(find mbzirc2020_task2_common)/robots/quad/mbzirc2020_task2_quad.urdf.xacro" />
+
+  <!-- gazebo plugin for sensors -->
+  <xacro:include filename="$(find mbzirc2020_task2_common)/robots/onboards/mbzirc2020_task2_quad/onboards.gazebo.xacro" />
+
+</robot>

--- a/mbzirc2020_task2/mbzirc2020_task2_common/robots/quad/mbzirc2020_task2_quad.urdf.xacro
+++ b/mbzirc2020_task2/mbzirc2020_task2_common/robots/quad/mbzirc2020_task2_quad.urdf.xacro
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<robot
+    xmlns:xacro="http://www.ros.org/wiki/xacro" name="hydrusx" >
+
+  <!-- basic kinematics model -->
+  <xacro:include filename="$(find mbzirc2020_task2_common)/urdf/common.xacro" />
+  <xacro:include filename="$(find mbzirc2020_task2_common)/urdf/link.urdf.xacro" />
+
+  <xacro:hydrusx_link self="1" child="2" rotor_direction="-1" with_battery = "0" />
+  <xacro:hydrusx_link self="2" child="3" rotor_direction="1"  with_battery = "0" />
+  <xacro:hydrusx_link self="3" child="4" rotor_direction="-1" with_battery = "0" />
+  <xacro:hydrusx_link self="4" child="4" rotor_direction="1"  with_battery = "0"/>
+
+  <!-- special battery arrangement -->
+  <xacro:extra_module name = "bat1" parent = "link1" visible = "1"
+                      model_url = "package://hydrus/urdf/mesh/modules/battery/Kypom-3000-6s.stl" scale="0.001">
+    <origin xyz="${link_length/2} 0.0 -0.048" rpy="${pi/2} 0 0"/>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.4108"/>
+      <inertia
+          ixx="0.0001" iyy="0.0006" izz="0.0006"
+          ixy="0.0" ixz="0.0"  iyz="0.0"/>
+    </inertial>
+  </xacro:extra_module>
+
+  <xacro:extra_module name = "bat2" parent = "link4" visible = "1"
+                      model_url = "package://hydrus/urdf/mesh/modules/battery/Kypom-3000-6s.stl" scale="0.001">
+    <origin xyz="${link_length/2} 0.0 -0.048" rpy="${pi/2} 0 0"/>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.4108"/>
+      <inertia
+          ixx="0.0001" iyy="0.0006" izz="0.0006"
+          ixy="0.0" ixz="0.0"  iyz="0.0"/>
+    </inertial>
+  </xacro:extra_module>
+
+  <!-- oboard sensors and processors -->
+  <xacro:include filename="$(find mbzirc2020_task2_common)/robots/onboards/mbzirc2020_task2_quad/onboards.urdf.xacro" />
+  <xacro:onboards link = "2" />
+
+</robot>

--- a/mbzirc2020_task2/mbzirc2020_task2_common/urdf/common.xacro
+++ b/mbzirc2020_task2/mbzirc2020_task2_common/urdf/common.xacro
@@ -1,0 +1,100 @@
+<?xml version="1.0"?>
+<robot
+    xmlns:xacro="http://www.ros.org/wiki/xacro" name="hydrusx_common" >
+
+  <!-- kinematics [m] -->
+  <xacro:property name="link_length" value=".6" />
+  <xacro:property name="protector_radius" value=".1925" />
+
+  <xacro:property name="head_leg_offset" value="0.0525" />
+  <xacro:property name="general_leg_offset" value="0.05" />
+  <xacro:property name="end_leg_offset" value="0.5355" />
+
+  <!-- collision model parameter -->
+  <xacro:property name="leg_collision_model_height" value="0.1715" />
+
+  <!-- dynamics -->
+  <xacro:property name="max_force" value="18" /> <!-- [N] -->
+
+  <xacro:macro name="link_model" params="type with_leg:=${with_leg}">
+    <!-- for fcl in planning -->
+    <collision>
+      <origin rpy="${-pi/2} 0 0" xyz="${link_length* 0.5} 0 0"/>
+      <geometry>
+        <mesh filename="package://hydrus/urdf/mesh/link/${type}_link.dae"/>
+      </geometry>
+    </collision>
+
+    <visual>
+      <origin rpy="${-pi/2} 0 0" xyz="${link_length* 0.5} 0 0"/>
+      <geometry>
+        <mesh filename="package://hydrus/urdf/mesh/link/${type}_link.dae"/>
+      </geometry>
+    </visual>
+  </xacro:macro>
+
+  <xacro:macro name="extra_module" params="name parent *origin *inertial visible:=0 collision:=0 model_url:=1 scale:=1">
+    <joint name="${parent}2${name}" type="fixed">
+      <parent link="${parent}"/>
+      <child link="${name}"/>
+      <xacro:insert_block name="origin" />
+    </joint>
+    <link name="${name}">
+      <xacro:insert_block name="inertial" />
+      <xacro:if value="${visible == 1}">
+        <visual>
+          <!-- the origin of link_frame and visual_frame should be identical -->
+          <origin rpy="${-pi/2} 0 0" xyz="0 0 0"/>
+          <geometry>
+            <mesh filename="${model_url}" scale= "${scale} ${scale} ${scale}"/>
+          </geometry>
+        </visual>
+      </xacro:if>
+      <xacro:if value="${collision == 1}">
+        <collision>
+          <!-- the origin of link_frame and visual_frame should be identical -->
+          <origin rpy="${-pi/2} 0 0" xyz="0 0 0"/>
+          <geometry>
+            <mesh filename="${model_url}" scale= "${scale} ${scale} ${scale}"/>
+          </geometry>
+        </collision>
+      </xacro:if>
+    </link>
+  </xacro:macro>
+
+  <xacro:macro name="standard_leg" params="parent self:=${self} *origin">
+      <xacro:extra_module name = "leg${self}" parent = "${parent}" visible = "1" collision = "1"
+                          model_url = "package://hydrus/urdf/mesh/modules/mechanical/standard_legs.dae" >
+        <xacro:insert_block name="origin" />
+        <inertial>
+          <!-- short leg:
+          <origin xyz="0.0 0.0 -0.055380" rpy="0 0 0"/>
+          <mass value="0.043000"/>
+          <inertia
+              ixx="0.000088" iyy="0.000088" izz="0.000000"
+              ixy="0.000000" ixz="0.000000" iyz="0.000000"/>
+          -->
+          <!-- standard leg: -->
+          <origin xyz="0.0 0.0 -0.0852" rpy="0 0 0"/>
+          <mass value="0.047000"/>
+          <inertia
+              ixx="0.000259" iyy="-0.000281" izz="0.000010"
+              ixy="0.000000" ixz="0.000000" iyz="0.000000"/>
+        </inertial>
+      </xacro:extra_module>
+  </xacro:macro>
+
+  <!-- friction -->
+  <xacro:macro name="friction" params="self">
+    <gazebo reference="link${self}">
+      <mu1>0.1</mu1>
+      <mu2>0.1</mu2>
+    </gazebo>
+  </xacro:macro>
+
+  <xacro:macro name="damping_factor" params="link">
+    <gazebo reference="${link}">
+      <dampingFactor>0.00</dampingFactor>
+    </gazebo>
+  </xacro:macro>
+</robot>

--- a/mbzirc2020_task2/mbzirc2020_task2_common/urdf/link.urdf.xacro
+++ b/mbzirc2020_task2/mbzirc2020_task2_common/urdf/link.urdf.xacro
@@ -1,0 +1,174 @@
+<?xml version="1.0"?>
+<robot
+    xmlns:xacro="http://www.ros.org/wiki/xacro" name="hydrusx_link" >
+
+  <!-- D-H kai description(different from prof.nakamura) -->
+  <xacro:macro name="hydrusx_link" params="self child rotor_direction with_leg:=1 with_battery:=1">
+
+    <!-- link -->
+    <link name="link${self}">
+      <!-- head -->
+      <xacro:if value="${self == 1}">
+        <inertial>
+          <origin xyz="${link_length* 0.5 + 0.055120} 0.0 0.011580" rpy="0 0 0"/>
+          <mass value="0.566650"/>
+          <inertia
+              ixx="0.001804" iyy="0.017972" izz="0.019248"
+              ixy="0.000021" ixz="0.000372" iyz="0.000000"/>
+        </inertial>
+        <xacro:link_model type="head" />
+      </xacro:if>
+      <xacro:unless value="${self == 1}">
+
+        <!-- tail -->
+        <xacro:if value="${self == child}">
+          <inertial>
+            <origin xyz="${link_length * 0.5 + -0.013450} 0.0 0.012830" rpy="0 0 0"/>
+            <mass value="0.495530"/>
+            <inertia
+                ixx="0.001758" iyy="0.013619" izz="0.014910"
+                ixy="0.000020" ixz="-0.000076" iyz="0.000000"/>
+          </inertial>
+          <xacro:link_model type="end" />
+        </xacro:if>
+        <xacro:unless value="${self == child}">
+          <!-- general -->
+          <inertial>
+            <origin xyz="${link_length * 0.5 + 0.038190} 0.0 0.010950" rpy="0 0 0"/>
+            <mass value="0.597720"/>
+            <inertia
+                ixx="0.001828" iyy="0.021127" izz="0.022388"
+                ixy="0.000021" ixz="0.000260" iyz="0.000000"/>
+          </inertial>
+          <xacro:link_model type="general" />
+        </xacro:unless>
+      </xacro:unless>
+    </link>
+
+    <xacro:damping_factor link ="link${self}"/>
+
+    <!-- rotor -->
+    <joint name="rotor${self}" type="continuous">
+      <limit effort="100.0" lower="0" upper="${max_force}" velocity="0.5"/> <!-- force range -->
+      <parent link="link${self}"/>
+      <child link="thrust${self}"/>
+      <origin rpy="0 0 0" xyz="${link_length* 0.5} 0 0"/>
+      <axis xyz="0 0 ${rotor_direction}"/>
+    </joint>
+
+    <link name="thrust${self}">
+      <!-- visual & collisiont -->
+      <inertial>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <mass value="0.0001"/>
+        <inertia
+            ixx="0.00001" ixy="0.0" ixz="0.0"
+            iyy="0.00001" iyz="0.0"
+            izz="0.00002"/>
+      </inertial>
+    </link>
+    <xacro:damping_factor link ="thrust${self}"/>
+
+    <!-- battery: -->
+    <!-- use default battery: -->
+    <xacro:if value="${with_battery == 1}">
+      <xacro:extra_module name = "bat${self}" parent = "link${self}" visible = "1"
+                          model_url = "package://hydrus/urdf/mesh/modules/battery/VOLTON-PG-1300LP2-6s.stl" scale="0.001">
+        <origin xyz="${link_length/2} 0.0 -0.048" rpy="${pi/2} 0 0"/>
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.194"/>
+          <inertia
+              ixx="0.00005" iyy="0.00012" izz="0.00011"
+              ixy="0.0" ixz="0.0" iyz="0.0"/>
+        </inertial>
+      </xacro:extra_module>
+    </xacro:if>
+
+    <!-- leg -->
+    <xacro:if value="${with_leg == 1}">
+      <!-- head -->
+      <xacro:if value="${self == 1}">
+        <xacro:standard_leg parent = "link${self}" >
+          <origin xyz="${head_leg_offset} 0.0 0" rpy="0 0 0"/>
+        </xacro:standard_leg>
+      </xacro:if>
+      <xacro:unless value="${self == 1}">
+        <xacro:standard_leg parent = "link${self}" >
+          <origin xyz="${general_leg_offset} 0.0 0" rpy="0 0 0"/>
+        </xacro:standard_leg>
+        <!-- tail -->
+        <xacro:if value="${self == child}">
+          <xacro:standard_leg parent = "link${self}" self= "${self + 1}" >
+            <origin xyz="${end_leg_offset} 0.0 0" rpy="0 0 0"/>
+          </xacro:standard_leg>
+        </xacro:if>
+      </xacro:unless>
+    </xacro:if>
+
+    <!-- joint -->
+    <xacro:unless value="${self == child}">
+      <joint name="joint${self}" type="revolute">
+        <limit effort="10.0" lower="${-pi/2}" upper="${pi/2}" velocity="0.5"/>
+        <parent link="link${self}"/>
+        <child link="link${child}"/>
+        <origin rpy="0 0 0" xyz="${link_length} 0 0"/>
+        <axis xyz="0 0 1"/>
+        <dynamics damping="0.9" friction="0.05"/>
+      </joint>
+    </xacro:unless>
+
+    <xacro:if value="${self == 1}">
+      <!-- dummy root link for KDL -->
+      <link name="root">
+        <inertial>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <mass value="0.00001"/>
+          <inertia
+              ixx="0.000001" ixy="0.0" ixz="0.0"
+              iyy="0.000001" iyz="0.0"
+              izz="0.000002"/>
+        </inertial>
+      </link>
+      <joint name="root_joint" type="fixed">
+        <parent link="root"/>
+        <child link="link${self}"/>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <axis xyz="0 0 1"/>
+      </joint>
+    </xacro:if>
+
+    <!-- hardware interface -->
+    <xacro:unless value="${self == child}">
+      <transmission name="joint_tran${self}">
+        <type>transmission_interface/SimpleTransmission</type>
+        <joint name="joint${self}">
+          <!-- TODO: effort is torque, maybe position is enough -->
+          <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+        </joint>
+        <actuator name="servo{self}">
+          <!-- TODO: effort is torque, maybe position is enough -->
+          <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+          <mechanicalReduction>1</mechanicalReduction>
+        </actuator>
+      </transmission>
+    </xacro:unless>
+
+    <transmission name="rotor_tran${self}">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="rotor${self}">
+        <!-- TODO: effort is torque, maybe position is enough -->
+        <hardwareInterface>RotorInterface</hardwareInterface>
+      </joint>
+      <actuator name="rotor${self}">
+        <!-- TODO: effort is torque, maybe position is enough -->
+        <hardwareInterface>RotorInterface</hardwareInterface>
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+
+    <xacro:friction self ="${self}"/>
+
+  </xacro:macro>
+
+</robot>

--- a/mbzirc2020_task2/mbzirc2020_task2_simulation/gazebo_model/world/mbzirc2020_task2_light.world
+++ b/mbzirc2020_task2/mbzirc2020_task2_simulation/gazebo_model/world/mbzirc2020_task2_light.world
@@ -127,7 +127,7 @@
       <brick_size>0.3 0.2 0.2</brick_size>
       <brick_color>1.0 0.0 0.0</brick_color>
       <brick_mass>0.381</brick_mass>
-      <count>50</count>
+      <count>200</count>
     </plugin>
 
   </world>

--- a/mbzirc2020_task2/mbzirc2020_task2_simulation/gazebo_model/world/mbzirc2020_task2_single_object.world
+++ b/mbzirc2020_task2/mbzirc2020_task2_simulation/gazebo_model/world/mbzirc2020_task2_single_object.world
@@ -78,7 +78,7 @@
         <collision name='collision'>
           <geometry>
             <box>
-              <size>0.2 0.2 0.3</size>
+              <size>0.3 0.3 0.3</size>
             </box>
           </geometry>
           <max_contacts>10</max_contacts>
@@ -93,7 +93,7 @@
           <cast_shadows>0</cast_shadows>
           <geometry>
             <box>
-              <size>0.2 0.2 0.3</size>
+              <size>0.3 0.3 0.3</size>
             </box>
           </geometry>
           <material>
@@ -108,6 +108,10 @@
         <gravity>1</gravity>
       </link>
     </model>
+    <gazebo reference='object'>
+      <mu1>0.5</mu1>
+      <mu2>0.5</mu2>
+    </gazebo>
 
   </world>
 </sdf>

--- a/mbzirc2020_task2/mbzirc2020_task2_simulation/urdf/gzplugin_grasp_fix.urdf.xacro
+++ b/mbzirc2020_task2/mbzirc2020_task2_simulation/urdf/gzplugin_grasp_fix.urdf.xacro
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root
+    xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+    xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+    xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+    xmlns:xacro="http://ros.org/wiki/xacro">
+
+  <xacro:macro name="gzplugin_grasp_fix">
+    <gazebo>
+      <plugin name="gazebo_grasp_fix" filename="libgazebo_grasp_fix.so">
+        <!--
+            NOTE: The finger tips are linked together with the links before, because they are connected with a
+            fixed joint. Gazebo makes one whole link out of this automatically. When listing the 9\
+            _*_tip links
+            here, they won't be found in the SDF.
+        -->
+        <arm>
+          <arm_name>hydrusx_arm</arm_name>
+          <palm_link>link3</palm_link>
+          <gripper_link>link2</gripper_link>
+          <gripper_link>link4</gripper_link>
+          <gripper_link>root</gripper_link>
+        </arm>
+        <forces_angle_tolerance>100</forces_angle_tolerance>
+        <update_rate>4</update_rate>
+        <grip_count_threshold>4</grip_count_threshold>
+        <max_grip_count>8</max_grip_count>
+        <release_tolerance>0.005</release_tolerance>
+        <disable_collisions_on_attach>false</disable_collisions_on_attach>
+        <contact_topic>__default_topic__</contact_topic>
+      </plugin>
+    </gazebo>
+  </xacro:macro>
+
+</root>


### PR DESCRIPTION
@tongtybj @skn047 @KeitaIto123 
Task2用にHydrusのロボットモデル、パラメータを追加しました．
今後モデルやパラメータはTask2用にいじっていくことになると思うので干渉しないようにファイルを作りました．
また、grasp pluginを入れたことでシミュレーションで物体把持を行うことができるようになっています．
これを使う際にロボットモデルのCollisionモデルの変更が必要になっています．