### PR TITLE
Modified the hydrus model for task3

### DIFF
--- a/mbzirc2020_task3/mbzirc2020_task3_common/launch/hydrus_bringup.launch
+++ b/mbzirc2020_task3/mbzirc2020_task3_common/launch/hydrus_bringup.launch
@@ -19,6 +19,7 @@
     <arg name="estimate_mode"  value= "$(arg estimate_mode)" />
     <arg name="headless" value="$(arg headless)" />
     <arg name="worldtype" value="$(arg gazebo_world)" />
+    <arg name="onboards_model" value="tx2_zed_201810" />
     <arg name="direct_model" value="True" />
     <arg name="direct_model_name" value="$(find mbzirc2020_task3_common)/robots/hydrus.urdf.xacro" if="$(eval (1 - arg('simulation')))"/>
     <arg name="direct_model_name" value="$(find mbzirc2020_task3_common)/robots/hydrus.gazebo.xacro" if="$(eval arg('simulation'))"/>

--- a/mbzirc2020_task3/mbzirc2020_task3_common/robots/hydrus.gazebo.xacro
+++ b/mbzirc2020_task3/mbzirc2020_task3_common/robots/hydrus.gazebo.xacro
@@ -1,11 +1,82 @@
 <?xml version="1.0"?>
 <robot
     xmlns:xacro="http://www.ros.org/wiki/xacro" name="hydrusx" >
-
   <!-- base robot model -->
   <xacro:include filename="$(find mbzirc2020_task3_common)/robots/hydrus.urdf.xacro" />
 
-  <!-- gazebo plugin for sensors -->
-  <xacro:include filename="$(find hydrus)/robots/onboards/tx2_zed_201810/onboards.gazebo.xacro" />
+  <!-- gazebo plugin for default controller and sensors -->
+  <xacro:include filename="$(find hydrus)/robots/default.gazebo.xacro" />
+
+  <!-- sensors -->
+  <!-- 1. stereo camera: depth, color based on left camera -->
+  <xacro:extra_module name = "zed_left_camera_frame" parent = "zed_camera_center">
+    <origin xyz="0.002 0.03 0" rpy="0 0 0"/>
+    <inertial>
+      <mass value = "0.00001" />
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <inertia
+          ixx="0.000001" ixy="0.0" ixz="0.0"
+          iyy="0.000001" iyz="0.0"
+          izz="0.000002"/>
+    </inertial>
+  </xacro:extra_module>
+  <xacro:extra_module name = "zed_left_camera_optical_frame" parent = "zed_left_camera_frame">
+    <origin xyz="0 0 0" rpy="${-pi / 2} 0 ${-pi / 2}"/>
+    <inertial>
+      <mass value = "0.00001" />
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <inertia
+          ixx="0.000001" ixy="0.0" ixz="0.0"
+          iyy="0.000001" iyz="0.0"
+          izz="0.000002"/>
+    </inertial>
+  </xacro:extra_module>
+
+  <!-- gazebo plugin -->
+  <gazebo reference="zed_left_camera_frame">
+    <sensor type="depth" name="zed_depth_camera">
+      <update_rate>20.0</update_rate>
+      <camera name="head">
+        <horizontal_fov>1.57</horizontal_fov>
+        <image>
+          <width>1280</width>
+          <height>720</height>
+          <format>RGB</format>
+        </image>
+        <clip>
+          <near>0.02</near>
+          <far>300</far>
+        </clip>
+        <noise>
+          <type>gaussian</type>
+          <mean>0.0</mean>
+          <stddev>0.007</stddev>
+        </noise>
+      </camera>
+      <plugin name="depth_camera" filename="libgazebo_ros_openni_kinect.so">
+        <baseline>0.06</baseline>
+        <alwaysOn>true</alwaysOn>
+        <updateRate>0.0</updateRate>
+        <cameraName>zed</cameraName>
+        <imageTopicName>rgb/image_rect_color</imageTopicName>
+        <cameraInfoTopicName>rgb/camera_info</cameraInfoTopicName>
+        <depthImageTopicName>depth/depth_registered</depthImageTopicName>
+        <depthImageInfoTopicName>depth/camera_info</depthImageInfoTopicName>
+        <pointCloudTopicName>point_cloud/cloud_registered</pointCloudTopicName>
+        <frameName>zed_left_camera_optical_frame</frameName>
+        <pointCloudCutoff>0.05</pointCloudCutoff>
+        <distortionK1>0</distortionK1>
+        <distortionK2>0</distortionK2>
+        <distortionK3>0</distortionK3>
+        <distortionT1>0</distortionT1>
+        <distortionT2>0</distortionT2>
+        <CxPrime>0</CxPrime>
+        <Cx>0</Cx>
+        <Cy>0</Cy>
+        <focalLength>0</focalLength>
+        <hackBaseline>0</hackBaseline>
+      </plugin>
+    </sensor>
+  </gazebo>
 
 </robot>

--- a/mbzirc2020_task3/mbzirc2020_task3_common/robots/hydrus.urdf.xacro
+++ b/mbzirc2020_task3/mbzirc2020_task3_common/robots/hydrus.urdf.xacro
@@ -2,15 +2,154 @@
 <robot
     xmlns:xacro="http://www.ros.org/wiki/xacro" name="hydrusx" >
 
-  <!-- base kinematics model -->
-  <xacro:include filename="$(find hydrus)/robots/quad/default.urdf.xacro" />
+  <!-- basic kinematics model -->
+  <xacro:include filename="$(find hydrus)/urdf/common.xacro" />
+  <xacro:include filename="$(find hydrus)/urdf/link.urdf.xacro" />
 
-  <!-- oboard sensors and processors -->
-  <xacro:include filename="$(find hydrus)/robots/onboards/tx2_zed_201810/onboards.urdf.xacro" />
-  <xacro:onboards link = "2" />
+  <xacro:hydrusx_link links="4" self="1" rotor_direction="-1" with_battery = "1" old_version = "1" />
+  <xacro:hydrusx_link links="4" self="2" rotor_direction="1"  with_battery = "1" old_version = "1" />
+  <xacro:hydrusx_link links="4" self="3" rotor_direction="-1" with_battery = "1" old_version = "1" />
+  <xacro:hydrusx_link links="4" self="4" rotor_direction="1"  with_battery = "1" old_version = "1" />
+
+  <!-- onboard -->
+  <!-- 1.  processor -->
+  <!-- 1.1 flight controller -->
+  <xacro:extra_module name = "fc" parent = "link2" visible = "1"
+                      model_url = "package://hydrus/urdf/mesh/ver1/flight_controller/fc_euclid201806.dae"> <!-- same with intel euclid -->
+    <origin xyz="${link_length / 2 + 0.2281} ${-4.4*0.001} 0.03533" rpy="0 0 0"/>
+    <inertial>
+      <mass value = "0.05" />
+      <origin xyz="${11.48*0.001} ${4.3*0.001} ${-9.4*0.001}" rpy="0 0 0"/>
+      <inertia
+          ixx="0.00001" ixy="0.0" ixz="0.0"
+          iyy="0.00001" iyz="0.0"
+          izz="0.00002"/>
+    </inertial>
+  </xacro:extra_module>
+  <!-- end: flight controller -->
+
+  <!-- 1.2 processor: jetson tx2 -->
+  <xacro:extra_module name = "pc" parent = "link3" visible = "1"
+                      model_url = "package://hydrus/urdf/mesh/ver1/processor/jetson_tx2.dae"
+                      scale="0.001" >
+    <origin xyz="0.086 0.0 ${-0.0192}" rpy="0 0 ${pi}"/>
+    <inertial>
+      <mass value = "0.181" />
+      <origin xyz="0 ${-5 * 0.001} 0" rpy="0 0 0"/>
+      <inertia
+          ixx="0.00001" ixy="0.0" ixz="0.0"
+          iyy="0.00001" iyz="0.0"
+          izz="0.00001"/>
+    </inertial>
+  </xacro:extra_module>
+  <!-- end: processor: jetson tx2 -->
+
+  <!-- 2.  sensor -->
+  <!-- 2.1 leddar one -->
+  <xacro:extra_module name = "leddarone" parent = "link3" visible = "1"
+                      model_url = "package://hydrus/urdf/mesh/sensor/leddar_one_tx2_attached_mode.dae">
+    <origin xyz="0.0866 0.0 -0.06267" rpy="0 ${pi} 0"/>
+    <inertial>
+      <origin xyz="-0.007950 0.000000 -0.000140" rpy="0 0 0"/>
+      <mass value="0.029000"/>
+      <inertia
+          ixx="0.000010" iyy="0.000008" izz="0.000008"
+          ixy="0.000000" ixz="0.000000" iyz="0.000000"/>
+    </inertial>
+  </xacro:extra_module>
+  <!-- end: leddar one -->
+
+  <!-- 2.2 gps -->
+  <xacro:extra_module name = "gps" parent = "link2" visible = "1"
+                      model_url = "package://hydrus/urdf/mesh/sensor/gps_ublox_m8n.dae">
+    <origin xyz="${link_length/2 + 0.1925} 0.0 0.152" rpy="0 0 0"/>
+    <inertial>
+      <origin xyz="0.000000 0.000000 -0.062510" rpy="0 0 0"/>
+      <mass value="0.053000"/>
+      <inertia
+          ixx="0.000503" iyy="0.000503" izz="0.000010"
+          ixy="0.000000" ixz="0.000000" iyz="0.000000"/>
+    </inertial>
+  </xacro:extra_module>
+  <xacro:extra_module name = "magnet" parent = "gps">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <inertial>
+      <mass value = "0.00001" />
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <inertia
+          ixx="0.000001" ixy="0.0" ixz="0.0"
+          iyy="0.000001" iyz="0.0"
+          izz="0.000002"/>
+    </inertial>
+  </xacro:extra_module>
+  <!-- end: gps -->
+
+  <!-- 2.3 sensor: zed mini with servo -->
+  <xacro:extra_module name = "zed_mini_servo_up" parent = "link2" visible = "1"
+                      model_url = "package://hydrus/urdf/mesh/ver1/sensor/zed_mini_servo_up.dae">
+    <origin xyz="${link_length/2 + 0.28715} 0.0 -0.04015" rpy="0 0 0"/>
+    <inertial>
+      <mass value = "0.021" />
+      <origin xyz="${-21.77 * 0.001} 0 ${10.3 * 0.001}" rpy="0 0 0"/>
+      <inertia
+          ixx="0.0" ixy="0.0" ixz="0.0"
+          iyy="0.0" iyz="0.0"
+          izz="0.0"/>
+    </inertial>
+  </xacro:extra_module>
+
+  <joint name="zed_mini_servo_joint" type="revolute">
+    <limit effort="0.2" lower="-1.6" upper="1.6" velocity="0.1"/>
+    <parent link="zed_mini_servo_up"/>
+    <child link="zed_mini_servo_down"/>
+    <origin rpy="0 0 0" xyz="0 0.0 0"/>
+    <axis xyz="1 0 0"/>
+    <dynamics damping="0.01" friction="0.0"/>
+  </joint>
+
+  <link name="zed_mini_servo_down">
+    <inertial>
+      <origin xyz="${-21.35 * 0.001} 0 ${-16.4 * 0.001}" rpy="0 0 0"/>
+      <mass value="0.079" />
+      <inertia
+          ixx="0.00001" iyy="0.00012" izz="0.00012"
+          ixy="0" ixz="0" iyz="0"/>
+    </inertial>
+    <visual>
+      <origin xyz="${-14.75 * 0.001} 0 ${-19 * 0.001}" rpy="0 ${pi/2} ${pi/2}"/>
+      <geometry>
+        <mesh filename="package://hydrus/urdf/mesh/ver1/sensor/zed_mini_servo_down.dae"/>
+      </geometry>
+    </visual>
+  </link>
+
+  <!-- to create the zed center frame -->
+  <xacro:extra_module name = "zed_camera_center" parent = "zed_mini_servo_down" visible = "0" >
+    <origin xyz="${-14.75 * 0.001} 0 ${-19 * 0.001}" rpy="0 ${pi/2} ${pi/2}"/>
+    <inertial>
+      <mass value = "0.0" />
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <inertia
+          ixx="0.0" ixy="0.0" ixz="0.0"
+          iyy="0.0" iyz="0.0"
+          izz="0.0"/>
+    </inertial>
+  </xacro:extra_module>
+
+  <transmission name="zed_mini_servo_joint_tran">
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="zed_mini_servo_joint">
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="zed_mini_servo_joint">
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <!-- end: sensor: zed mini with servo -->
 
   <!-- add sheet as a rigid point, meanings less inertia -->
-  <xacro:property name="sheet_mass" value=".41" />
+  <xacro:property name="sheet_mass" value=".433" />
   <xacro:extra_module name = "sheet_anchor1" parent = "leg1" visible = "0" >
     <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
     <inertial>


### PR DESCRIPTION
The current hydrus model for  task3 is based on zed mini for fire detection.
The main difference from based mode `tx2_zed_201810` is the battery type and the arrangement.
To balance the robot along with the sheet, we use four small battery (e.g. 1300mAh) distributed in each link as shown in following image:
![Screenshot from 2019-08-05 11-12-53](https://user-images.githubusercontent.com/3666095/62434076-22d43c80-b772-11e9-94a1-088aec2f853e.png)
