### PR TITLE
Fix the wrong robot model of ground_mode in task2

### DIFF
--- a/mbzirc2020/mbzirc2020_task2/mbzirc2020_task2_common/robots/hydrus_ground_mode.urdf.xacro
+++ b/mbzirc2020/mbzirc2020_task2/mbzirc2020_task2_common/robots/hydrus_ground_mode.urdf.xacro
@@ -3,9 +3,117 @@
     xmlns:xacro="http://www.ros.org/wiki/xacro" name="hydrusx" >
 
   <!-- base kinematics model -->
-  <!-- base kinematics model -->
-  <xacro:include filename="$(find mbzirc2020_common)/robots/default.urdf.xacro" />
-  <xacro:robot_model tilt_angle = "0" horizontal_vio = "1" default_battery = "0" with_leg = "0"  />
+  <xacro:include filename="$(find hydrus)/urdf/common.xacro" />
+  <xacro:include filename="$(find hydrus)/urdf/link.urdf.xacro" />
+  <xacro:include filename="$(find mbzirc2020_common)/urdf/fixed_link.urdf.xacro" />
+
+  <xacro:hydrusx_link links="4" self="1" rotor_direction="-1" with_battery = "0" with_leg = "0" tilt_mode="0" />
+  <xacro:hydrusx_fixed_link self="2" rotor_direction="1"  with_battery = "0" with_leg = "0" tilt_angle = "0" />
+  <xacro:hydrusx_fixed_link self="3" rotor_direction="-1" with_battery = "0" with_leg = "0" tilt_angle = "0" />
+  <xacro:hydrusx_link links="4" self="4" rotor_direction="1"  with_battery = "0" with_leg = "0" tilt_mode="0" />
+
+  <!-- onboard -->
+  <!-- 1.  processor -->
+  <!-- 1.1 flight controller -->
+  <xacro:extra_module name = "fc" parent = "link2" visible = "1"
+                      model_url = "package://mbzirc2020_common/urdf/mesh/modules/processor/spinal_fixed_joint.dae">
+    <origin xyz="${link_length / 2 + 0.2432} 0.03951 -0.002" rpy="0 0 0"/>
+    <inertial>
+      <mass value = "0.0416" />
+      <origin xyz="0.0136 0.004 0" rpy="0 0 0"/>
+      <inertia
+          ixx="0.00001" ixy="0.0" ixz="0.0"
+          iyy="0.00001" iyz="0.0"
+          izz="0.00002"/>
+    </inertial>
+  </xacro:extra_module>
+  <!-- end: flight controller -->
+
+  <!-- 1.2 processor: neuron for link3 -->
+  <xacro:extra_module name = "neuron3" parent = "link2" visible = "1"
+                      model_url = "package://mbzirc2020_common/urdf/mesh/modules/processor/neuron_unit.dae" >
+    <origin xyz="${link_length / 2 + 0.315} 0.07 0.015" rpy="0 0 0"/>
+    <inertial>
+      <mass value = "0.01" />
+      <origin xyz="0 0  0.01" rpy="0 0 0"/>
+      <inertia
+          ixx="0.00000" ixy="0.0" ixz="0.0"
+          iyy="0.00000" iyz="0.0"
+          izz="0.00000"/>
+    </inertial>
+  </xacro:extra_module>
+  <!-- end: processor: neuron -->
+
+  <!-- 1.3 processor: intel upboard -->
+  <!-- TODO: change to brix -->
+  <xacro:extra_module name = "pc" parent = "link2" visible = "1"
+                      model_url = "package://mbzirc2020_common/urdf/mesh/modules/processor/intel_upboard_fixed_joint_unit.dae" >
+    <origin xyz="${link_length / 2 + 0.2845} 0.011 0.016" rpy="0 0 ${pi}"/>
+    <inertial>
+      <mass value = "0.117" />
+      <origin xyz="${21 * 0.001} ${4 * 0.001} ${12 * 0.001}" rpy="0 0 0"/>
+      <inertia
+          ixx="0.00004" ixy="0.0" ixz="0.0"
+          iyy="0.00008" iyz="0.0"
+          izz="0.00011"/>
+    </inertial>
+  </xacro:extra_module>
+  <!-- end: intel upboard -->
+
+
+  <!-- 2.  sensor -->
+  <!-- 2.1 leddar one -->
+  <xacro:extra_module name = "leddarone" parent = "link2" visible = "1"
+                      model_url = "package://mbzirc2020_common/urdf/mesh/modules/sensor/ledder_one_fixed_joint_unit.dae">
+    <origin xyz="${link_length/2 + 0.31814} 0.05614 -0.022" rpy="${pi} 0 0"/>
+    <inertial>
+      <origin xyz="-0.008 0.0 0.0" rpy="0 0 0"/>
+      <mass value="0.02"/>
+      <inertia
+          ixx="0.0" iyy="0.0" izz="0.0"
+          ixy="0.0" ixz="0.0" iyz="0.0"/>
+    </inertial>
+  </xacro:extra_module>
+  <!-- end: leddar one -->
+
+  <!-- 2.2 gps -->
+  <xacro:extra_module name = "gps" parent = "link2" visible = "1"
+                      model_url = "package://hydrus/urdf/mesh/sensor/gps_ublox_m8n.dae">
+    <origin xyz="${link_length/2 + 0.1925} 0.0 0.152" rpy="0 0 0"/>
+    <inertial>
+      <origin xyz="0.000000 0.000000 -0.013" rpy="0 0 0"/>
+      <mass value="0.042"/>
+      <inertia
+          ixx="0.00006" iyy="0.00006" izz="0.000007"
+          ixy="0.000000" ixz="0.000000" iyz="0.000000"/>
+    </inertial>
+  </xacro:extra_module>
+  <xacro:extra_module name = "magnet" parent = "gps">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <inertial>
+      <mass value = "0.00001" />
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <inertia
+          ixx="0.000001" ixy="0.0" ixz="0.0"
+          iyy="0.000001" iyz="0.0"
+          izz="0.000002"/>
+    </inertial>
+  </xacro:extra_module>
+  <!-- end: gps -->
+
+  <!-- 2.3 horizontal rs-t265 (option VIO) -->
+  <xacro:extra_module name = "realsense1_pose_frame" parent = "link2" visible = "1"
+                      model_url = "package://mbzirc2020_common/urdf/mesh/modules/sensor/center_leg_rs_t265_unit.STL">
+    <origin xyz="${link_length/2 + 0.3281} -0.00114 -0.04" rpy="0 0 ${-pi/4}"/>
+    <inertial>
+      <mass value = "0.073" />
+      <origin xyz="-0.01 -0.007 0" rpy="0 0 0"/>
+      <inertia
+          ixx="0.0" ixy="0.0" ixz="0.0"
+          iyy="0.0" iyz="0.0"
+          izz="0.0"/>
+    </inertial>
+  </xacro:extra_module>
 
   <!-- special battery arrangement -->
   <xacro:extra_module name = "bat1" parent = "link1" visible = "1"
@@ -32,24 +140,6 @@
     </inertial>
   </xacro:extra_module>
 
-  <!-- processor: intel upboard -->
-  <!-- TODO: change to brix -->
-  <xacro:extra_module name = "pc" parent = "link2" visible = "1"
-                      model_url = "package://mbzirc2020_common/urdf/mesh/modules/processor/intel_upboard_fixed_joint_unit.dae" >
-    <origin xyz="${link_length / 2 + 0.2845} 0.011 0.016" rpy="0 0 ${pi}"/>
-    <inertial>
-      <mass value = "0.117" />
-      <origin xyz="${21 * 0.001} ${4 * 0.001} ${12 * 0.001}" rpy="0 0 0"/>
-      <inertia
-          ixx="0.00004" ixy="0.0" ixz="0.0"
-          iyy="0.00008" iyz="0.0"
-          izz="0.00011"/>
-    </inertial>
-  </xacro:extra_module>
-  <!-- end: intel upboard -->
-
-  <!-- sensor -->
-  <!-- TODO: add realsense d435 without servo -->
 
   <!-- actuated and omni leg when ground_mode -->
   <!-- actuated legs -->


### PR DESCRIPTION
The ground mode in task2 is very special.
So, the robot.urdf.xacro should not be derived from mbzirc2020_comon