### PR TITLE
[mbzirc2020_common] add hydrus interface and sample script

### DIFF
--- a/mbzirc2020/mbzirc2020_common/CMakeLists.txt
+++ b/mbzirc2020/mbzirc2020_common/CMakeLists.txt
@@ -1,197 +1,20 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(mbzirc2020_common)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
-
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
   roscpp
+  rospy
 )
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
+catkin_python_setup()
 
-
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
-
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend tag for "message_generation"
-##   * add a build_depend and a exec_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
-##     but can be declared for certainty nonetheless:
-##     * add a exec_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs  # Or other packages containing msgs
-# )
-
-################################################
-## Declare ROS dynamic reconfigure parameters ##
-################################################
-
-## To declare and build dynamic reconfigure parameters within this
-## package, follow these steps:
-## * In the file package.xml:
-##   * add a build_depend and a exec_depend tag for "dynamic_reconfigure"
-## * In this file (CMakeLists.txt):
-##   * add "dynamic_reconfigure" to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * uncomment the "generate_dynamic_reconfigure_options" section below
-##     and list every .cfg file to be processed
-
-## Generate dynamic reconfigure parameters in the 'cfg' folder
-# generate_dynamic_reconfigure_options(
-#   cfg/DynReconf1.cfg
-#   cfg/DynReconf2.cfg
-# )
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if your package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES mbzirc2020_common
 #  CATKIN_DEPENDS roscpp
 #  DEPENDS system_lib
 )
-
-###########
-## Build ##
-###########
-
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
 include_directories(
 # include
   ${catkin_INCLUDE_DIRS}
 )
-
-## Declare a C++ library
-# add_library(${PROJECT_NAME}
-#   src/${PROJECT_NAME}/mbzirc2020_common.cpp
-# )
-
-## Add cmake target dependencies of the library
-## as an example, code may need to be generated before libraries
-## either from message generation or dynamic reconfigure
-# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Declare a C++ executable
-## With catkin_make all packages are built within a single CMake context
-## The recommended prefix ensures that target names across packages don't collide
-# add_executable(${PROJECT_NAME}_node src/mbzirc2020_common_node.cpp)
-
-## Rename C++ executable without prefix
-## The above recommended prefix causes long target names, the following renames the
-## target back to the shorter version for ease of user use
-## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
-# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
-
-## Add cmake target dependencies of the executable
-## same as for the library above
-# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Specify libraries to link a library or executable target against
-# target_link_libraries(${PROJECT_NAME}_node
-#   ${catkin_LIBRARIES}
-# )
-
-#############
-## Install ##
-#############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark executables and/or libraries for installation
-# install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_node
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_mbzirc2020_common.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)

--- a/mbzirc2020/mbzirc2020_common/scripts/hydrus/__init__.py
+++ b/mbzirc2020/mbzirc2020_common/scripts/hydrus/__init__.py
@@ -1,0 +1,1 @@
+from .hydrus_interface import HydrusInterface

--- a/mbzirc2020/mbzirc2020_common/scripts/hydrus/hydrus_interface.py
+++ b/mbzirc2020/mbzirc2020_common/scripts/hydrus/hydrus_interface.py
@@ -1,0 +1,176 @@
+import rospy
+from sensor_msgs.msg import JointState
+from nav_msgs.msg import Odometry
+from aerial_robot_msgs.msg import FlightNav
+import numpy as np
+import ros_numpy as ros_np
+from tf.transformations import *
+from std_msgs.msg import Empty
+import math
+
+class HydrusInterface:
+    def __init__(self):
+        self.joint_state_sub_ = rospy.Subscriber('hydrusx/joint_states', JointState, self.jointStateCallback)
+        self.joint_ctrl_pub_ = rospy.Publisher('hydrusx/joints_ctrl', JointState, queue_size = 1)
+        self.cog_odom_sub_ = rospy.Subscriber('uav/cog/odom', Odometry, self.cogOdomCallback)
+        self.baselink_odom_sub_ = rospy.Subscriber('uav/baselink/odom', Odometry, self.baselinkOdomCallback)
+        self.nav_pub_ = rospy.Publisher('uav/nav', FlightNav, queue_size = 1)
+        self.start_pub_ = rospy.Publisher('teleop_command/start', Empty, queue_size = 1)
+        self.takeoff_pub_ = rospy.Publisher('teleop_command/takeoff', Empty, queue_size = 1)
+        self.land_pub_ = rospy.Publisher('teleop_command/land', Empty, queue_size = 1)
+        self.force_landing_pub_ = rospy.Publisher('teleop_command/force_landing', Empty, queue_size = 1)
+
+        self.joint_update_freq_ = rospy.get_param("~joint_update_freq", 20)
+
+        self.joint_state_ = None
+        self.cog_odom_ = None
+        self.baselink_odom_ = None
+
+    def jointStateCallback(self, msg):
+        self.joint_state_ = msg
+
+    def cogOdomCallback(self, msg):
+        self.cog_odom_ = msg
+
+    def baselinkOdomCallback(self, msg):
+        self.baselink_odom_ = msg
+
+    #time [ms]
+    def setJointAngle(self, target_joint_state, time = 1000):
+        joint_seq_len = int(time * self.joint_update_freq_ / 1000.0)
+        joint_seq = []
+
+        if joint_seq_len > 1:
+            for position, name in zip(target_joint_state.position, target_joint_state.name):
+                current_position = self.joint_state_.position[self.joint_state_.name.index(name)]
+                joint_seq.append(np.linspace(current_position, position, num = joint_seq_len, endpoint = True))
+            joint_seq = np.stack(joint_seq).transpose()
+        else:
+            joint_seq = [target_joint_state.position]
+
+        joint_msg = JointState()
+        joint_msg.name = target_joint_state.name
+
+        for joint_pos in joint_seq:
+            joint_msg.header.stamp = rospy.Time.now()
+            joint_msg.position = joint_pos
+            self.joint_ctrl_pub_.publish(joint_msg)
+            rospy.sleep(1.0 / self.joint_update_freq_)
+
+    def getJointState(self):
+        return self.joint_state_
+
+    def start(self):
+        self.start_pub_.publish()
+
+    def takeoff(self):
+        self.takeoff_pub_.publish()
+
+    def startAndTakeoff(self):
+        self.start()
+        rospy.sleep(0.5)
+        self.takeoff()
+
+    def land(self):
+        self.land_pub_.publish()
+
+    def forceLanding(self):
+        self.force_landing_pub_.publish()
+
+    def getBaselinkOdom(self):
+        return self.baselink_odom_
+
+    def getCogOdom(self):
+        return self.cog_odom_
+
+    def getBaselinkPos(self):
+        return ros_np.numpify(self.baselink_odom_.pose.pose.position)
+
+    def getBaselinkRot(self):
+        return quaternion_matrix(ros_np.numpify(self.baselink_odom_.pose.pose.orientation))
+
+    def getBaselinkRPY(self):
+        return euler_from_quaternion(ros_np.numpify(self.baselink_odom_.pose.pose.orientation))
+
+    def getBaselinkLinearVel(self):
+        return ros_np.numpify(self.baselink_odom_.twist.twist.linear)
+
+    def getCogPos(self):
+        return ros_np.numpify(self.cog_odom_.pose.pose.position)
+
+    def getCogRot(self):
+        return quaternion_matrix(ros_np.numpify(self.cog_odom_.pose.pose.orientation))
+
+    def getCogRPY(self):
+        return euler_from_quaternion(ros_np.numpify(self.cog_odom_.pose.pose.orientation))
+
+    def getCogLinearVel(self):
+        return ros_np.numpify(self.cog_odom_.twist.twist.linear)
+
+    #navigation
+    def noNavigation(self):
+        nav_msg = FlightNav()
+        nav_msg.header.stamp = rospy.Time.now()
+        nav_msg.pos_xy_nav_mode = FlightNav.NO_NAVIGATION
+        nav_msg.psi_nav_mode = FlightNav.NO_NAVIGATION
+        nav_msg.pos_z_nav_mode = FlightNav.NO_NAVIGATION
+        self.navigation(nav_msg)
+
+    def goPos(self, frame, target_xy, target_z, target_yaw):
+        nav_msg = FlightNav()
+        if frame == 'global':
+            nav_msg.control_frame = nav_msg.WORLD_FRAME
+        elif frame == 'local':
+            nav_msg.control_frame = nav_msg.LOCAL_FRAME
+        else:
+            rospy.logerr('invalid frame %s' % (frame))
+            return
+
+        nav_msg.header.stamp = rospy.Time.now()
+        nav_msg.target = FlightNav.BASELINK
+        nav_msg.pos_xy_nav_mode = FlightNav.POS_MODE
+        nav_msg.pos_z_nav_mode = FlightNav.POS_MODE
+        nav_msg.psi_nav_mode = FlightNav.POS_MODE
+        nav_msg.target_pos_x = target_xy[0]
+        nav_msg.target_pos_y = target_xy[1]
+        nav_msg.target_psi = target_yaw
+        nav_msg.target_pos_z = target_z
+
+        self.nav_pub_.publish(nav_msg)
+
+    def isConvergent(self, frame, target_xy, target_z, target_yaw, pos_conv_thresh, yaw_conv_thresh, vel_conv_thresh):
+        current_xy = self.getBaselinkPos()[0:2]
+        current_z = self.getBaselinkPos()[2]
+        current_yaw = self.getBaselinkRPY()[2]
+        current_vel = self.getBaselinkLinearVel()
+
+        if frame == 'global':
+            delta_pos = np.array([target_xy[0] - current_xy[0], target_xy[1] - current_xy[1], target_z - current_z])
+        elif frame == 'local':
+            delta_pos = np.array([target_xy[0], target_xy[1], target_z - current_z])
+        else:
+            rospy.logerr('invalid frame %s' % (frame))
+            return
+
+        delta_yaw = target_yaw - current_yaw
+        if delta_yaw > np.pi:
+            delta_yaw -= np.pi * 2
+        elif delta_yaw < -np.pi:
+            delta_yaw += np.pi * 2
+
+        if np.linalg.norm(delta_pos) < pos_conv_thresh and abs(delta_yaw) < yaw_conv_thresh and np.linalg.norm(current_vel) < vel_conv_thresh:
+            return True
+        else:
+            return False
+
+    def goPosWaitConvergence(self, frame, target_xy, target_z, target_yaw, pos_conv_thresh = 0.1, yaw_conv_thresh = 0.1, vel_conv_thresh = 0.1, timeout = 30):
+        self.goPos(frame, target_xy, target_z, target_yaw)
+        start_time = rospy.get_time()
+
+        while not self.isConvergent(frame, target_xy, target_z, target_yaw, pos_conv_thresh, yaw_conv_thresh, vel_conv_thresh):
+            elapsed_time = rospy.get_time() - start_time
+            if elapsed_time > timeout:
+                return False
+            rospy.sleep(0.1)
+
+        return True

--- a/mbzirc2020/mbzirc2020_common/scripts/sample_takeoff_gopos_transform.py
+++ b/mbzirc2020/mbzirc2020_common/scripts/sample_takeoff_gopos_transform.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+import rospy
+from hydrus.hydrus_interface import *
+from sensor_msgs.msg import JointState
+
+rospy.init_node("hydrus_interface")
+robot = HydrusInterface()
+rospy.sleep(1)
+
+robot.startAndTakeoff()
+rospy.sleep(20)
+
+result = robot.goPosWaitConvergence('global', [3, 3], 2, 0.2)
+print(result)
+
+rospy.sleep(2)
+
+joint_state = JointState()
+joint_state.name = ['joint1', 'joint3']
+joint_state.position = [1.0, 1.0]
+robot.setJointAngle(joint_state, time = 5000)

--- a/mbzirc2020/mbzirc2020_common/setup.py
+++ b/mbzirc2020/mbzirc2020_common/setup.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+d = generate_distutils_setup(
+    packages=['mbzirc2020_common'],
+    package_dir={'': 'scripts'}
+)
+
+setup(**d)


### PR DESCRIPTION
Hydrusのpython interfaceを追加しました．使うには
```
catkin build mbzirc2020_common
```
してください．

また、サンプルは
```
roslaunch mbzirc2020_common bringup.launch simulation:=True real_machine:=False headless:=False
rosrun mbzirc2020_common sample sample_takeoff_gopos_transform.py
```
で動きます．

これはいずれaerial_robotリポジトリに移行します．