### PR TITLE
terrain check and vio sensor sanity check

### DIFF
--- a/mbzirc2020/mbzirc2020_task2/mbzirc2020_task2_common/config/_passive_gripper/EgomotionEstimation.yaml
+++ b/mbzirc2020/mbzirc2020_task2/mbzirc2020_task2_common/config/_passive_gripper/EgomotionEstimation.yaml
@@ -51,6 +51,8 @@ estimator:
                 estimate_mode: 6 # 1<<1 + 1<<2
         alt:
                 estimate_mode: 1 # 1<<0
+                outlier_threshold: 0.5
+                inlier_threshold: 0.25                                
         gps:
                 estimate_mode: 1 # 1<<0
         vo:

--- a/mbzirc2020/mbzirc2020_task2/mbzirc2020_task2_common/config/_ring_gripper/EgomotionEstimation.yaml
+++ b/mbzirc2020/mbzirc2020_task2/mbzirc2020_task2_common/config/_ring_gripper/EgomotionEstimation.yaml
@@ -51,6 +51,8 @@ estimator:
                 estimate_mode: 6 # 1<<1 + 1<<2
         alt:
                 estimate_mode: 1 # 1<<0
+                outlier_threshold: 0.5
+                inlier_threshold: 0.25                                
         gps:
                 estimate_mode: 1 # 1<<0
         vo:


### PR DESCRIPTION
@chibi314 

https://github.com/tongtybj/aerial_robot/pull/375 をcheckoutして、 明日屋外で試してほしいです。

今は、最小段差(`outlier_threshold`)を0.5mに指定しています。 
こちらでは、0.6mの段差を問題なく検出することができました。

ただ、段差を検出して、距離が短くなっているときは、高度センサの値は使いません。つまり、この間はVIOのz速度とIMUの加速度だけが使われます。この間に、さらにVIOが暴走してたら、システムで止めることができないので、手動でatti modeに切り替えるしかありません。
