### PR TITLE
Update dependency version

### DIFF
--- a/travis.rosinstall
+++ b/travis.rosinstall
@@ -1,8 +1,8 @@
 - git:
     local-name: aerial_robot
-    uri: https://github.com/tongtybj/aerial_robot.git
-    version: robot_namespace
+    uri: https://github.com/JSKAerialRobot/aerial_robot.git
+    version: 458f1a2
 - git: 
     local-name: aerial_robot_recognition
-    uri: https://github.com/tongtybj/aerial_robot_recognition.git
+    uri: https://github.com/JSKAerialRobot/aerial_robot_recognition.git
     version: master


### PR DESCRIPTION
Update version of [aerial_robot](https://github.com/JSKAerialRobot/aerial_robot) and [aerial_robot_recognition](https://github.com/JSKAerialRobot/aerial_robot_recognition), which are both public right now.