### PR TITLE
[mbzirc2020_common] disable mocap.launch when estimate_mode is 0

### DIFF
--- a/mbzirc2020/mbzirc2020_common/launch/base_sensors.launch
+++ b/mbzirc2020/mbzirc2020_common/launch/base_sensors.launch
@@ -5,6 +5,7 @@
   <arg name="simulation" default="false" />
   <arg name="horizontal_vio" default="false" />
   <arg name="robot_ns" default="hydrus" />
+  <arg name="estimate_mode" default="0" />
 
   <group ns="$(arg robot_ns)">
 
@@ -25,7 +26,7 @@
         </include>
 
         <!-- mocap -->
-        <include file="$(find aerial_robot_base)/launch/external_module/mocap.launch" />
+        <include file="$(find aerial_robot_base)/launch/external_module/mocap.launch" if="$(eval arg('estimate_mode') != 0)"/>
 
         <!-- leddar one -->
         <include file="$(find leddar_one)/launch/leddar_one.launch" >

--- a/mbzirc2020/mbzirc2020_common/launch/bringup.launch
+++ b/mbzirc2020/mbzirc2020_common/launch/bringup.launch
@@ -79,6 +79,7 @@
     <arg name="simulation" value="$(arg simulation)" />
     <arg name="horizontal_vio" value="$(arg horizontal_vio)" />
     <arg name="robot_ns" value="$(arg robot_ns)" />
+    <arg name="estimate_mode" value="$(arg estimate_mode)"/>
   </include >
 
   ###########  Servo Bridge  ###########


### PR DESCRIPTION
mocap.launch will not be launched when estimate_mode is 0 (outdoor).